### PR TITLE
Update migrations to inherit from AR::Migration[4.2]

### DIFF
--- a/db/migrate/20160201032247_create_spree_user_prices.rb
+++ b/db/migrate/20160201032247_create_spree_user_prices.rb
@@ -1,4 +1,4 @@
-class CreateSpreeUserPrices < ActiveRecord::Migration
+class CreateSpreeUserPrices < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_user_prices do |t|
       t.references :variant

--- a/db/migrate/20160219021842_add_role_reference_to_spree_user_prices.rb
+++ b/db/migrate/20160219021842_add_role_reference_to_spree_user_prices.rb
@@ -1,4 +1,4 @@
-class AddRoleReferenceToSpreeUserPrices < ActiveRecord::Migration
+class AddRoleReferenceToSpreeUserPrices < ActiveRecord::Migration[4.2]
   def change
     add_reference :spree_user_prices, :role, index: true
   end

--- a/db/migrate/20160617021405_add_currency_to_spree_user_prices.rb
+++ b/db/migrate/20160617021405_add_currency_to_spree_user_prices.rb
@@ -1,4 +1,4 @@
-class AddCurrencyToSpreeUserPrices < ActiveRecord::Migration
+class AddCurrencyToSpreeUserPrices < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_user_prices, :currency, :string
   end


### PR DESCRIPTION
To make this work in Rails > 5 we have to specify the migration version
that the migration was written for. This commit make the migrations
suitable from 4.2, so it will be working for older versions of Solidus
as well.